### PR TITLE
 Implemented geocoding functionality using Google Maps API

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -155,6 +155,14 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -761,6 +769,11 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
     },
     "form-data": {
       "version": "2.5.0",

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
     "import:data": "node seedDB.js"
   },
   "dependencies": {
+    "axios": "^0.21.1",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.5",
     "dotenv": "^8.2.0",

--- a/server/utils/geocoding.js
+++ b/server/utils/geocoding.js
@@ -1,0 +1,37 @@
+const axios = require("axios");
+const API_KEY = process.env.GOOGLE_MAPS_API_KEY;
+
+/* 
+
+Call this function in the user controllers for creating and modifying profiles in order to
+convert the address string received from the front end into an object with the coordinates,
+so that the coordinates may be stored in the database.
+
+For example:
+ 
+If "290 bremner blvd toronto" is passed in, { lat: 43.6426283, lng: -79.3868547 } will be returned
+
+*/
+
+const getCoordsFromAddress = async (address) => {
+  const addressURIString = encodeURIComponent(address);
+  const response = await axios.get(
+    `https://maps.googleapis.com/maps/api/geocode/json?
+    address=${addressURIString}
+    &key=${API_KEY}`
+  );
+
+  const data = response.data;
+
+  if (!data || data.status === "ZERO_RESULTS") {
+    const error = new Error("Could not find a location for that address");
+    error.code(422);
+    throw error;
+  }
+
+  const coordinates = data.results[0].geometry.location;
+
+  return coordinates;
+};
+
+module.exports = getCoordsFromAddress;


### PR DESCRIPTION
When called with an address passed into it, this function will return an object with the coordinates of that address. I used the Google Maps API, which I have $200 worth of free credits for. It should be fine since I am only using it for geocoding (I am using mapbox to render the map on the front-end), which means that there will only need to be one call made, whenever the user creates or modifies their profile. 